### PR TITLE
Fix login logo text

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -50,7 +50,7 @@ export default function LoginPage() {
               <div className="inline-flex items-center justify-center w-16 h-16 bg-white/20 rounded-full mb-4">
                 <Phone className="w-8 h-8 text-white" />
               </div>
-              <h1 className="text-2xl font-bold text-white mb-2">電話番号・注文管理</h1>
+              <h1 className="text-2xl font-bold text-white mb-2">テレクローン</h1>
               <p className="text-white/80 text-sm">システムにアクセス</p>
             </div>
 


### PR DESCRIPTION
## Summary
- update login page heading to say テレクローン instead of 電話番号・注文管理

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b84f78c6c832a83addac06bb030ba