### PR TITLE
Remove tagline from login page

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -51,7 +51,6 @@ export default function LoginPage() {
                 <Phone className="w-8 h-8 text-white" />
               </div>
               <h1 className="text-2xl font-bold text-white mb-2">テレクローン</h1>
-              <p className="text-white/80 text-sm">システムにアクセス</p>
             </div>
 
             {/* ログインボタン */}


### PR DESCRIPTION
## Summary
- remove "システムにアクセス" tagline from the login page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b89db209c832aa3ca869f43f5315f